### PR TITLE
Convert List to String before using json_decode

### DIFF
--- a/autoload/composer.vim
+++ b/autoload/composer.vim
@@ -35,13 +35,14 @@ function! s:get_nested(dict, key, ...) abort
 endfunction
 
 ""
-" Get Dict from JSON {string}.
-function! s:json_decode(string) abort
+" Get Dict from JSON {expr}.
+function! s:json_decode(expr) abort
   try
     if exists('*json_decode')
-      return json_decode(a:string)
+      let expr = type(a:expr) == type([]) ? join(a:expr, "\n") : a:expr
+      return json_decode(expr)
     else
-      return projectionist#json_parse(a:string)
+      return projectionist#json_parse(a:expr)
     endif
   catch /^Vim\%((\a\+)\)\=:E474/
     call s:throw('composer.json cannot be parsed')


### PR DESCRIPTION
Neovim's json_decode() accepts both a String and a List as argument, but
regular vim's json_decode() only accepts a String. Therefore reading
from composer.json with readfile(), and passing the result to
json_decode(), was failing in regular vim.
