### PR TITLE
Remove leading backslash from class name before passing it to composer

### DIFF
--- a/autoload/composer/autoload.vim
+++ b/autoload/composer/autoload.vim
@@ -47,8 +47,9 @@ function! s:find_file(fqn) abort
     call s:throw('autoload.php not found. Run composer install.')
   endif
 
+  let fqn = substitute(a:fqn, '^\', '', '')
   let s = '$c = require("' . autoload . '"); echo $c->findFile($argv[1]);'
-  let path = system('php -r ' . shellescape(s) . ' ' . shellescape(a:fqn))
+  let path = system('php -r ' . shellescape(s) . ' ' . shellescape(fqn))
 
   if v:shell_error != 0
     call s:throw('Command exited with code %d', v:shell_error)


### PR DESCRIPTION
I was having trouble jumping to classes from files like Laravel's `config/app.php`, where classes are referenced by their full name, instead of being imported at the top.

This commit makes it possible to pass the result from `composer#namespace#expand()` to `s:find_file()`, as done in
https://github.com/noahfrederick/vim-composer/blob/734b90bff5b55d05a831756fa8e68d0dc1fb1944/autoload/composer/autoload.vim#L27-L32