### PR TITLE
Simplify path to class given by composer

### DIFF
--- a/autoload/composer/autoload.vim
+++ b/autoload/composer/autoload.vim
@@ -59,7 +59,7 @@ function! s:find_file(fqn) abort
     call s:throw('Cannot find file for %s', a:fqn)
   endif
 
-  return path
+  return simplify(path)
 endfunction
 
 ""


### PR DESCRIPTION
This simplifies

```
vendor/composer/../guzzlehttp/guzzle/src/Client.php
```

to

```
vendor/guzzlehttp/guzzle/src/Client.php
```

which is caused by Composer doing `__DIR__.'/../guzzle/src/Client.php'`.

I did this so my statusline won't be cluttered by an unnecessarily long path name.