### PR TITLE
Generate file namespace from PSR-4

### DIFF
--- a/autoload/composer.vim
+++ b/autoload/composer.vim
@@ -185,6 +185,36 @@ function! s:project_query(key, ...) dict abort
 endfunction
 
 ""
+" Convert {path} to a namespace value if its in composer.json PSR4 autoload
+function! s:project_path_namespace(path, ...) dict abort
+  let default = get(a:000, 0, '')
+  " get all the psr4 namespaces from composer.json
+  let psr4 = items(s:get_nested(self.json(), 'autoload.psr-4', {}))
+  " remove the path to project root if supplied
+  let file_path = substitute(a:path, '^'.call('s:project_path', a:000, self).'/', '', 'i')
+
+  " if we were given a path with filename strip it
+  if fnamemodify(file_path, ':e') ==# 'php'
+    let file_path = fnamemodify(file_path, ':h')
+  endif
+
+  " loop psr4 namespaces
+  for space in psr4
+    let found = matchstrpos(file_path, space[1].'/')
+
+    " we matched this path from the start of ours so..
+    " .. replace fwd slash with back slash
+    " .. remove any trailing slash
+    " .. only operate on the part after namespace directory
+    if found[1]  == 0
+      return substitute(space[0] . substitute(strpart(file_path, found[2]), '/', '\', 'g'), '\$', '\1', '')
+    endif
+  endfor
+
+  return default
+endfunction
+
+""
 " Get Dict of packages required in composer.json, where the keys represent
 " package names and the values represent the version constraints.
 function! s:project_packages_required() dict abort
@@ -270,7 +300,7 @@ function! s:project_search(keyword) dict abort
   return self.cache.get(cache)
 endfunction
 
-call s:add_methods('project', ['json', 'lock', 'installed_json', 'query', 'scripts', 'makeprg', 'exec', 'commands', 'packages_required', 'packages_installed', 'search'])
+call s:add_methods('project', ['json', 'lock', 'installed_json', 'query', 'scripts', 'makeprg', 'exec', 'commands', 'packages_required', 'packages_installed', 'search', 'path_namespace'])
 
 let s:cache_prototype = {'cache': {}}
 
@@ -328,6 +358,14 @@ function! composer#query(key) abort
 endfunction
 
 ""
+" @public
+" PSR4 namespace for file path
+function! composer#path_namespace(path, ...) abort
+  let default = get(a:000, 0, '')
+  return s:project().path_namespace(a:path, default)
+endfunction
+
+""
 " @private
 " Set up Composer buffers.
 function! composer#buffer_setup() abort
@@ -347,6 +385,10 @@ function! composer#buffer_setup() abort
     ""
     " Insert a use statement for the class/interface/trait under the cursor.
     nnoremap <buffer> <Plug>(composer-use) :<C-u>execute composer#namespace#use(0)<CR>
+
+    ""
+    " Insert the namespace statement of current class based on the PSR-4 autoload.
+    nnoremap <buffer> <Plug>(composer-namespace) :<C-u>execute composer#namespace#insert()<CR>
   endif
 
   silent doautocmd User Composer

--- a/autoload/composer.vim
+++ b/autoload/composer.vim
@@ -190,6 +190,8 @@ function! s:project_path_namespace(path, ...) dict abort
   let default = get(a:000, 0, '')
   " get all the psr4 namespaces from composer.json
   let psr4 = items(s:get_nested(self.json(), 'autoload.psr-4', {}))
+  let psr4_dev = items(s:get_nested(self.json(), 'autoload-dev.psr-4', {}))
+  let psr4 += psr4_dev
   " remove the path to project root if supplied
   let file_path = substitute(a:path, '^'.call('s:project_path', a:000, self).'/', '', 'i')
 

--- a/autoload/composer/namespace.vim
+++ b/autoload/composer/namespace.vim
@@ -3,6 +3,36 @@
 
 ""
 " @private
+" Insert namespace statement for current class based off the PSR-4 autoload
+" definition in composer.json
+function! composer#namespace#insert() abort
+  let namespace = composer#path_namespace(expand('%:h'))
+
+  if empty(namespace)
+    echohl WarningMsg
+    echomsg 'No namespace could be found'
+    echohl None
+    return
+  endif
+
+  if search('^\s*namespace\_s\_[[:alnum:]\\_]\+;', 'wbe') > 0
+    echohl WarningMsg
+    echomsg 'A namespace statment already exists'
+    echohl None
+    return
+  endif
+
+  let line = 'namespace ' . namespace . ';'
+  if search('<?\%(php\)\?', 'wbe') > 0
+    put=''
+    put=line
+  else
+    0put=line
+  endif
+endfunction
+
+""
+" @private
 " Insert use statement for [class], optionally with [alias]. If {sort} is
 " non-empty, also sort all use statements in the buffer.
 function! composer#namespace#use(sort, ...) abort

--- a/doc/composer.txt
+++ b/doc/composer.txt
@@ -53,6 +53,11 @@ in 'use' statements. For example, it does what you want with the cursor on
 
 Insert a use statement for the class, interface, or trait under the cursor.
 
+<Plug>(composer-namespace)
+
+Insert a namespace statement for the current class, based on the PSR-4 section
+in composer.json.
+
 ==============================================================================
 AUTOCOMMANDS                                           *composer-autocommands*
 
@@ -67,6 +72,9 @@ FUNCTIONS                                                 *composer-functions*
 
 composer#query({key})                                       *composer#query()*
   Query {key} from composer.json for current project.
+
+composer#path_namespace({path})                    *composer#path_namespace()*
+  Convert {path} to a namespace if in the PSR-4 autoload section.
 
 ==============================================================================
 ABOUT                                                         *composer-about*

--- a/doc/composer.txt
+++ b/doc/composer.txt
@@ -55,8 +55,7 @@ Insert a use statement for the class, interface, or trait under the cursor.
 
 <Plug>(composer-namespace)
 
-Insert a namespace statement for the current class, based on the PSR-4 section
-in composer.json.
+Insert the namespace statement of current class based on the PSR-4 autoload.
 
 ==============================================================================
 AUTOCOMMANDS                                           *composer-autocommands*
@@ -74,7 +73,7 @@ composer#query({key})                                       *composer#query()*
   Query {key} from composer.json for current project.
 
 composer#path_namespace({path})                    *composer#path_namespace()*
-  Convert {path} to a namespace if in the PSR-4 autoload section.
+  PSR4 namespace for file path
 
 ==============================================================================
 ABOUT                                                         *composer-about*

--- a/plugin/composer.vim
+++ b/plugin/composer.vim
@@ -46,6 +46,10 @@
 " <Plug>(composer-use)
 "
 " Insert a use statement for the class, interface, or trait under the cursor.
+"
+" <Plug>(composer-namespace)
+"
+" Insert the namespace statement of current class based on the PSR-4 autoload.
 
 ""
 " @section Autocommands, autocommands

--- a/t/project.vim
+++ b/t/project.vim
@@ -151,4 +151,36 @@ describe 'composer#project().cache'
   end
 end
 
+describe 's:project_path_namespace()'
+  before
+    execute 'edit' g:fixtures . 'project-composer/index.php'
+    let b:project = composer#project()
+
+    call b:project.cache.set('json', {
+\     "autoload": {
+\       "psr-4": {
+\          'Foo\Bar\': 'src',
+\          'Baz\Bar\': 'lib/php'
+\        }
+\      }
+\   })
+  end
+
+  after
+    bwipeout!
+  end
+
+  context 'with matching psr-4'
+    it 'returns the correct namespace'
+      Expect composer#path_namespace("lib/php/Sub/Class.php") ==# 'Baz\Bar\Sub'
+    end
+  end
+
+  context 'without matching psr-4'
+    it 'returns the correct namespace'
+      Expect composer#path_namespace("tests/Sub/Class.php") ==# ''
+    end
+  end
+end
+
 " vim: fdm=marker:sw=2:sts=2:et


### PR DESCRIPTION
This allows the user to automatically get/insert the namespace for a file based on its path if it exists in the psr-4 autoload config.

Example:

`nmap <buffer> gn <Plug>(composer-namespace)` to automatically add the namespace statement.

Or use the function `composer#path_namespace(path)` in a template file like for UltiSnips
```
snippet class
<?php

namespace `!v composer#path_namespace(expand('%:h')) `;

class ${2:`!p snip.rv = snip.basename[0].upper() + snip.basename[1:]`}
{
	${0}
}
endsnippet
```

